### PR TITLE
Make the Blend Button uninteractable when the tween is running

### DIFF
--- a/Scripts/Scenes/Utils/UITemplateBlendButton.cs
+++ b/Scripts/Scenes/Utils/UITemplateBlendButton.cs
@@ -23,7 +23,11 @@ namespace TheOneStudio.UITemplate.UITemplate.Scenes.Utils
 
         private void Awake() { this.button.onClick.AddListener(this.OnClick); }
 
-        private void OnClick() { DOTween.To(() => this.slider.value, x => this.OnValueChanged(this.slider.value = x), this.slider.value > 0.5f ? 0 : 1, this.duration); }
+        private void OnClick()
+        {
+            this.button.interactable = false;
+            DOTween.To(() => this.slider.value, x => this.OnValueChanged(this.slider.value = x), this.slider.value > 0.5f ? 0 : 1, this.duration).OnComplete(() => this.button.interactable = true);
+        }
 
         private void OnValueChanged(float arg0)
         {


### PR DESCRIPTION
<p align="center">
<img src="https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white" style="display: block; width: 100%"/>
</p>

<h1 align="center">
    UI Template
</h1>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
