### PR TITLE
Add methods to hide ads in UITemplateAdServiceWrapper

### DIFF
--- a/Scripts/Services/BreakAds/BreakAdsPopupView.cs
+++ b/Scripts/Services/BreakAds/BreakAdsPopupView.cs
@@ -8,6 +8,7 @@
     using ServiceImplementation.Configs;
     using Sirenix.OdinInspector;
     using TheOneStudio.UITemplate.UITemplate.Models.Controllers;
+    using TheOneStudio.UITemplate.UITemplate.Scripts.ThirdPartyServices;
     using TMPro;
     using UnityEngine;
     using UnityEngine.Scripting;
@@ -28,6 +29,7 @@
         private readonly BreakAdsViewHelper                breakAdsViewHelper;
         private readonly ThirdPartiesConfig                thirdPartiesConfig;
         private readonly UITemplateInventoryDataController inventoryDataController;
+        private readonly UITemplateAdServiceWrapper        uITemplateAdServiceWrapper;
 
         [Preserve]
         public BreakAdsPopupPresenter(
@@ -35,12 +37,14 @@
             ILogService                       logger,
             BreakAdsViewHelper                breakAdsViewHelper,
             ThirdPartiesConfig                thirdPartiesConfig,
-            UITemplateInventoryDataController inventoryDataController
+            UITemplateInventoryDataController inventoryDataController,
+            UITemplateAdServiceWrapper        uITemplateAdServiceWrapper
         ) : base(signalBus, logger)
         {
-            this.breakAdsViewHelper      = breakAdsViewHelper;
-            this.thirdPartiesConfig      = thirdPartiesConfig;
-            this.inventoryDataController = inventoryDataController;
+            this.breakAdsViewHelper         = breakAdsViewHelper;
+            this.thirdPartiesConfig         = thirdPartiesConfig;
+            this.inventoryDataController    = inventoryDataController;
+            this.uITemplateAdServiceWrapper = uITemplateAdServiceWrapper;
         }
 
         #endregion
@@ -52,6 +56,8 @@
 
         public override UniTask BindData()
         {
+            this.uITemplateAdServiceWrapper.HideBannerAd();
+            this.uITemplateAdServiceWrapper.HideAllMRec();
             this.SetupUI();
             return this.breakAdsViewHelper.BindData();
         }

--- a/Scripts/ThirdPartyServices/UITemplateAdServiceWrapper.cs
+++ b/Scripts/ThirdPartyServices/UITemplateAdServiceWrapper.cs
@@ -22,6 +22,7 @@ namespace TheOneStudio.UITemplate.UITemplate.Scripts.ThirdPartyServices
     using ServiceImplementation.Configs;
     using ServiceImplementation.Configs.Ads;
     using ServiceImplementation.IAPServices.Signals;
+    using Sirenix.Utilities;
     using TheOneStudio.UITemplate.UITemplate.Models.Controllers;
     using TheOneStudio.UITemplate.UITemplate.Scenes.Loading;
     using TheOneStudio.UITemplate.UITemplate.Services.BreakAds;
@@ -573,6 +574,12 @@ namespace TheOneStudio.UITemplate.UITemplate.Scripts.ThirdPartyServices
                 foreach (var mrecAdService in mrecAdServices) mrecAdService.HideMREC(placement, position);
                 this.logService.Log($"onelog: HideMREC, placement: {placement}");
             }
+        }
+
+        public virtual void HideAllMRec()
+        {
+            this.mrecAdServices.ForEach(mrecAdService => mrecAdService.HideAllMREC());
+            this.logService.Log($"onelog: HideAllMREC");
         }
 
         private void OnRemoveAdsComplete()


### PR DESCRIPTION
Introduced `HideAllMRec` method in `UITemplateAdServiceWrapper` to hide all MREC ads and log the action. Updated `BreakAdsPopupView` to utilize `HideBannerAd` and `HideAllMRec` methods for improved ad management during Break Ads popup display.

<p align="center">
<img src="https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white" style="display: block; width: 100%"/>
</p>

<h1 align="center">
    UI Template
</h1>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
