### PR TITLE
Add optional parameter to ShowNativeOverlayInterAd method

### DIFF
--- a/Scripts/ThirdPartyServices/UITemplateAdServiceWrapperCreative.cs
+++ b/Scripts/ThirdPartyServices/UITemplateAdServiceWrapperCreative.cs
@@ -127,7 +127,7 @@
         {
         }
 
-        public override void ShowNativeOverlayInterAd(string placement, Action<bool> onComplete)
+        public override void ShowNativeOverlayInterAd(string placement, Action<bool> onComplete, bool isHidePreviousMrec = true)
         {
             this.ShowInterstitialAd(placement, onComplete);
         }


### PR DESCRIPTION
Introduced the `isHidePreviousMrec` parameter to provide control over hiding previous MREC ads when showing a native overlay interstitial ad. Maintains backward compatibility by setting a default value for the new parameter.

<p align="center">
<img src="https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white" style="display: block; width: 100%"/>
</p>

<h1 align="center">
    UI Template
</h1>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
